### PR TITLE
Add basic Markdown highlighting

### DIFF
--- a/src/RichText.js
+++ b/src/RichText.js
@@ -130,15 +130,27 @@ function findWithRegex(regex, contentBlock: ContentBlock, callback: (start: numb
 /**
  * Passes rangeToReplace to modifyFn and replaces it in contentState with the result.
  */
-export function modifyText(contentState: ContentState, rangeToReplace: SelectionState, modifyFn: (text: string) => string, ...rest): ContentState {
-    let startKey = rangeToReplace.getStartKey(),
-        endKey = contentState.getKeyAfter(rangeToReplace.getEndKey()),
+export function modifyText(contentState: ContentState, rangeToReplace: SelectionState,
+                           modifyFn: (text: string) => string, ...rest): ContentState {
+    let getText = (key) => contentState.getBlockForKey(key).getText(),
+        startKey = rangeToReplace.getStartKey(),
+        startOffset = rangeToReplace.getStartOffset(),
+        endKey = rangeToReplace.getEndKey(),
+        endOffset = rangeToReplace.getEndOffset(),
         text = "";
 
-    for(let currentKey = startKey; currentKey && currentKey !== endKey; currentKey = contentState.getKeyAfter(currentKey)) {
-        let currentBlock = contentState.getBlockForKey(currentKey);
-        text += currentBlock.getText();
+
+    for(let currentKey = startKey;
+            currentKey && currentKey !== endKey;
+            currentKey = contentState.getKeyAfter(currentKey)) {
+        text += getText(currentKey).substring(startOffset, blockText.length);
+
+        // from now on, we'll take whole blocks
+        startOffset = 0;
     }
+
+    // add remaining part of last block
+    text += getText(endKey).substring(startOffset, endOffset);
 
     return Modifier.replaceText(contentState, rangeToReplace, modifyFn(text), ...rest);
 }

--- a/src/RichText.js
+++ b/src/RichText.js
@@ -21,6 +21,15 @@ const STYLES = {
     UNDERLINE: 'u'
 };
 
+const MARKDOWN_REGEX = {
+    LINK: /(?:\[([^\]]+)\]\(([^\)]+)\))|\<(\w+:\/\/[^\>]+)\>/g,
+    ITALIC: /([\*_])([\w\s]+?)\1/g,
+    BOLD: /([\*_])\1([\w\s]+?)\1\1/g
+};
+
+const USERNAME_REGEX = /@\S+:\S+/g;
+const ROOM_REGEX = /#\S+:\S+/g;
+
 export function contentStateToHTML(contentState: ContentState): string {
     return contentState.getBlockMap().map((block) => {
         let elem = BLOCK_RENDER_MAP.get(block.getType()).element;
@@ -45,9 +54,6 @@ export function contentStateToHTML(contentState: ContentState): string {
 export function HTMLtoContentState(html: string): ContentState {
     return ContentState.createFromBlockArray(convertFromHTML(html));
 }
-
-const USERNAME_REGEX = /@\S+:\S+/g;
-const ROOM_REGEX = /#\S+:\S+/g;
 
 /**
  * Returns a composite decorator which has access to provided scope.
@@ -107,12 +113,6 @@ export function getScopedMDDecorators(scope: any): CompositeDecorator {
 
     return markdownDecorators;
 }
-
-const MARKDOWN_REGEX = {
-    LINK: /(?:\[([^\]]+)\]\(([^\)]+)\))|\<(\w+:\/\/[^\>]+)\>/g,
-    ITALIC: /([\*_])([\w\s]+?)\1/g,
-    BOLD: /([\*_])\1([\w\s]+?)\1\1/g
-};
 
 /**
  * Utility function that looks for regex matches within a ContentBlock and invokes {callback} with (start, end)

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -97,13 +97,16 @@ export default class MessageComposerInput extends React.Component {
      * - whether we've got rich text mode enabled
      * - contentState was passed in
      */
-    createEditorState(contentState: ?ContentState): EditorState {
-        let func = contentState ? EditorState.createWithContent : EditorState.createEmpty;
-        const decoratorFunc = this.state.isRichtextEnabled ? RichText.getScopedRTDecorators :
-                              RichText.getScopedMDDecorators;
-        let args = contentState ? [contentState] : [];
-        args.push(new CompositeDecorator(decoratorFunc(this.props)));
-        return func(...args);
+    createEditorState(richText: boolean, contentState: ?ContentState): EditorState {
+        let decorators = richText ? RichText.getScopedRTDecorators(this.props) :
+                                    RichText.getScopedMDDecorators(this.props),
+            compositeDecorator = new CompositeDecorator(decorators);
+
+        if (contentState) {
+            return EditorState.createWithContent(contentState, compositeDecorator);
+        } else {
+            return EditorState.createEmpty(compositeDecorator);
+        }
     }
 
     componentWillMount() {
@@ -194,7 +197,7 @@ export default class MessageComposerInput extends React.Component {
                 if (contentJSON) {
                     let content = convertFromRaw(JSON.parse(contentJSON));
                     component.setState({
-                        editorState: component.createEditorState(content)
+                        editorState: component.createEditorState(this.state.isRichtextEnabled, content)
                     });
                 }
             }
@@ -341,16 +344,16 @@ export default class MessageComposerInput extends React.Component {
     }
 
     enableRichtext(enabled: boolean) {
-        if(enabled) {
+        if (enabled) {
             let html = mdownToHtml(this.state.editorState.getCurrentContent().getPlainText());
             this.setState({
-                editorState: this.createEditorState(RichText.HTMLtoContentState(html))
+                editorState: this.createEditorState(enabled, RichText.HTMLtoContentState(html))
             });
         } else {
-            let markdown = stateToMarkdown(this.state.editorState.getCurrentContent());
-            let contentState = ContentState.createFromText(markdown);
+            let markdown = stateToMarkdown(this.state.editorState.getCurrentContent()),
+                contentState = ContentState.createFromText(markdown);
             this.setState({
-                editorState: this.createEditorState(contentState)
+                editorState: this.createEditorState(enabled, contentState)
             });
         }
 

--- a/src/components/views/rooms/MessageComposerInput.js
+++ b/src/components/views/rooms/MessageComposerInput.js
@@ -99,10 +99,10 @@ export default class MessageComposerInput extends React.Component {
      */
     createEditorState(contentState: ?ContentState): EditorState {
         let func = contentState ? EditorState.createWithContent : EditorState.createEmpty;
+        const decoratorFunc = this.state.isRichtextEnabled ? RichText.getScopedRTDecorators :
+                              RichText.getScopedMDDecorators;
         let args = contentState ? [contentState] : [];
-        if(this.state.isRichtextEnabled) {
-            args.push(RichText.getScopedDecorator(this.props));
-        }
+        args.push(new CompositeDecorator(decoratorFunc(this.props)));
         return func(...args);
     }
 
@@ -341,11 +341,7 @@ export default class MessageComposerInput extends React.Component {
     }
 
     enableRichtext(enabled: boolean) {
-        this.setState({
-            isRichtextEnabled: enabled
-        });
-
-        if(!this.state.isRichtextEnabled) {
+        if(enabled) {
             let html = mdownToHtml(this.state.editorState.getCurrentContent().getPlainText());
             this.setState({
                 editorState: this.createEditorState(RichText.HTMLtoContentState(html))
@@ -357,6 +353,10 @@ export default class MessageComposerInput extends React.Component {
                 editorState: this.createEditorState(contentState)
             });
         }
+
+        this.setState({
+            isRichtextEnabled: enabled
+        });
     }
 
     handleKeyCommand(command: string): boolean {


### PR DESCRIPTION
**See also https://github.com/aviraldg/vector-web/pull/1**

Also fixed the behaviour of key shortcuts while in Markdown mode.
Still missing:
- [ ] Blockquotes
- [ ] Code blocks
- ?

To discuss:
- Strikethrough/underline (not available in standard markdown)
- Link editor in RichText mode
